### PR TITLE
Support multiple Alma IDs [Breaking change]

### DIFF
--- a/src/BCLib/PrimoServices/BibComponentTranslator.php
+++ b/src/BCLib/PrimoServices/BibComponentTranslator.php
@@ -51,7 +51,7 @@ class BibComponentTranslator
             $this->assignAlmaId($record->control);
         } catch (\Exception $e) {
             foreach ($this->components as $component) {
-                $component->alma_id = '';
+                $component->alma_ids = [];
             }
         }
 
@@ -90,7 +90,7 @@ class BibComponentTranslator
 
             foreach ($component_keys as $component_key) {
                 if (strpos($component_key, $pair->key) !== false) {
-                    $this->components[$component_key]->alma_id = $pair->val;
+                    $this->components[$component_key]->alma_ids[] = $pair->val;
                 }
             }
         }
@@ -104,6 +104,14 @@ class BibComponentTranslator
         if ($this->is_multi) {
             return $group->$field;
         }
-        return array('$$V' . $group->$field . '$$O' . $this->keys[0]);
+
+        $fieldValues = is_array($group->$field) ? $group->$field : array($group->$field);
+
+        // @TODO $that is a PHP5.3 compatibility kludge
+        $that = $this;
+
+        return array_map(function($fieldValue) use ($that) {
+            return '$$V' . $fieldValue . '$$O' . $that->keys[0];
+        }, $fieldValues);
     }
 }


### PR DESCRIPTION
The problem is that Primo can return an array of Alma IDs like so:

```json
                           "control" : {
                              "sourcerecordid" : "71346309370002201",
                              "sourceformat" : "MARC21",
                              "almaid" : [
                                 "47BIBSYS_NETWORK:71346309370002201",
                                 "47BIBSYS_STAVMUS:214217790002264",
                                 "47BIBSYS_NTNU_UB:2168667910002203",
                                 "47BIBSYS_NB:2192689930002202",
                                 "47BIBSYS_UBO:2175645040002204"
                              ],
                              "recordid" : "BIBSYS_ILS71346309370002201",
                              "sourcesystem" : "Alma",
                              "addsrcrecordid" : "998720037104702201",
                              "sourceid" : "BIBSYS_ILS"
                           },
```

This causes an array-to-string conversion error in [BibComponentTranslator:107](https://github.com/BCLibraries/primo-services/blob/master/src/BCLib/PrimoServices/BibComponentTranslator.php#L107) because `$group->$field` is now an array.

(There is also an example of multiple Alma IDs in `brief-search-result-local-02.json`)

My suggested fix involves renaming `alma_id` to `alma_ids` and making sure it's *always* an array. Let me know what you think.
