### PR TITLE
Add `resourcetype_facet` and `frbr_group_id` to `Bibrecord`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ foreach ($primo_result->results as $result) {
     $result->openurl_fulltext; // string[]
     $result->publisher;
     $result->reserves_info;
+    $result->resourcetype_facet; // string[]
     $result->sort_creator;
     $result->sort_date;
     $result->sort_title;

--- a/src/BCLib/PrimoServices/BibRecord.php
+++ b/src/BCLib/PrimoServices/BibRecord.php
@@ -115,6 +115,11 @@ class BibRecord
     public $getit = array();
 
     /**
+     * @var string
+     */
+    public $frbr_group_id = null;
+
+    /**
      * @var string[]
      */
     public $cover_images;

--- a/src/BCLib/PrimoServices/BibRecord.php
+++ b/src/BCLib/PrimoServices/BibRecord.php
@@ -87,6 +87,11 @@ class BibRecord
     /**
      * @var string[]
      */
+    public $resourcetype_facet = array();
+
+    /**
+     * @var string[]
+     */
     public $languages = array();
 
     /**

--- a/src/BCLib/PrimoServices/PNXTranslator.php
+++ b/src/BCLib/PrimoServices/PNXTranslator.php
@@ -107,6 +107,10 @@ class PNXTranslator
 
         $bib->getit = $this->extractGetIts($doc->{$this->_sear . 'GETIT'});
 
+        if ($this->extractField($facets, 'frbrtype') != '6') {
+            $bib->frbr_group_id = $this->extractField($facets, 'frbrgroupid');
+        }
+
         $this->extractPNXGroups($record, $bib);
 
         return $bib;

--- a/src/BCLib/PrimoServices/PNXTranslator.php
+++ b/src/BCLib/PrimoServices/PNXTranslator.php
@@ -87,6 +87,7 @@ class PNXTranslator
 
         $bib->creator_facet = $this->extractArray($facets, 'creatorcontrib');
         $bib->collection_facet = $this->extractArray($facets, 'collection');
+        $bib->resourcetype_facet = $this->extractArray($facets, 'rsrctype');
 
         $bib->link_to_source = $this->extractArray($sear_links, $this->_sear . 'linktosrc');
 


### PR DESCRIPTION
Even though `frbr_group_id` is mentioned in the README, it seems like it wasn't implemented yet.

I haven't been able to find any documentation on the `frbrtype`, have you? So far, I have only seen `frbrtype=5` for combined ("frbrized") records, and `frbrtype=6` for single records. Afaics there is no need for the `frbr_group_id` for single records. (I have no idea what frbrtype 1, 2, 3 and 4 might mean if they exists)

There is a similar way of handling it in https://github.com/scotdalton/exlibris-primo/blob/master/lib/exlibris/primo/pnx/frbr.rb , so I'm quite confident it's not *totally* off.