### PR TITLE
Fix so AlmaClient chooses correct Alma ID

### DIFF
--- a/src/BCLib/PrimoServices/Availability/AlmaClient.php
+++ b/src/BCLib/PrimoServices/Availability/AlmaClient.php
@@ -108,9 +108,10 @@ class AlmaClient implements AvailibilityClient
 
         foreach ($results as $result) {
             foreach ($result->components as $component) {
-                if ($component->delivery_category == 'Alma-P') {
-                    $component_key = preg_replace('/\D/', '', $component->source_record_id);
-                    $this->all_components[$component_key] = $component;
+                $delivery_category = explode('$$', $component->delivery_category);
+                if ($delivery_category[0] == 'Alma-P' && isset($component->alma_ids[$this->library])) {
+                    $alma_id = $component->alma_ids[$this->library];
+                    $this->all_components[$alma_id] = $component;
                 }
             }
         }

--- a/src/BCLib/PrimoServices/BibComponentTranslator.php
+++ b/src/BCLib/PrimoServices/BibComponentTranslator.php
@@ -89,8 +89,9 @@ class BibComponentTranslator
             $pair->key = array_pop($key_parts);
 
             foreach ($component_keys as $component_key) {
-                if (strpos($component_key, $pair->key) !== false) {
-                    $this->components[$component_key]->alma_ids[] = $pair->val;
+                if (strpos($component_key, $pair->key) !== false && strpos($pair->val, ':')) {
+                    list($institution, $institution_id) = explode(':', $pair->val);
+                    $this->components[$component_key]->alma_ids[$institution] = $institution_id;
                 }
             }
         }


### PR DESCRIPTION
Breaking change: I changed the `alma_ids` from

    ['institution1:id1', 'institution2:id2']

to

    ['institution1' => 'id1', 'institution2' => 'id2']

to make it easier to consume. I should have realized in #13, but I'm still struggling to get my head around the API response format, which is really dense. Sorry about that. (A new version bump is probably not needed since the commit is only two days old and we're still on 0.x.)

---

Some background:

Our library is part of a network zone consortium, which is probably why I run into a few issues. If you're interested, I've put up an example response here: https://gist.github.com/danmichaelo/6d5611592e396945b7a2

In short, `delivery` looks like this (notice the `$$I`s):

````
"delivery" : {
   "delcategory" : [
      "Alma-P$$IBIBSYS",
      "Alma-P$$ISINTEF",
      "Alma-P$$IUBO"
   ],
   "institution" : [
      "BIBSYS",
      "SINTEF",
      "UBO"
   ]
}
````

and `control` like this:

```json
{
   "sourcesystem" : "Alma",
   "sourceformat" : "MARC21",
   "sourcerecordid" : "71354134370002201",
   "recordid" : "BIBSYS_ILS71354134370002201",
   "almaid" : [
      "47BIBSYS_NETWORK:71354134370002201",
      "47BIBSYS_SINTEF:213995760002287",
      "47BIBSYS_UBO:2113615280002204"
   ],
   "sourceid" : "BIBSYS_ILS",
   "addsrcrecordid" : "990918105824702201"
}
```

Since I'm setting `$library` to `47BIBSYS_UBO`, I'm not interested in the `sourcerecordid` (which is the NZ id), but the ID for `47BIBSYS_UBO` (2113615280002204). So that's what my PR is about.

I *think* the PR shouldn't break responses like the one in `brief-search-result-local-01.json`, but testing is needed :)